### PR TITLE
Add option to enable/disable unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 before_script:
   - mkdir BUILD && cd BUILD
-  - CXX="g++ -m64" CC="gcc -m64" cmake .. -DCMAKE_BUILD_TYPE=$BUILD
+  - CXX="g++ -m64" CC="gcc -m64" cmake .. -DCMAKE_BUILD_TYPE=$BUILD -DOCX_QEMU_ARM_BUILD_TESTS=ON
 
 script:
   - make && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ include(ExternalProject)
 
 project(ocx-qemu-arm)
 
+option(OCX_QEMU_ARM_BUILD_TESTS "Build unit tests" OFF)
+
 set(CMAKE_CXX_STANDARD 11)
 
 set(CAPSTONE_HOME $ENV{CAPSTONE_HOME})
@@ -83,7 +85,9 @@ target_link_libraries(ocx-qemu-arm ${UNICORN_LIB} capstone-static)
 
 install(TARGETS ocx-qemu-arm DESTINATION lib)
 
-enable_testing()
-add_test(NAME ocx-qemu-arm
-         COMMAND $<TARGET_FILE:ocx-test-runner>
-                 $<TARGET_FILE:ocx-qemu-arm> Cortex-A53)
+if(OCX_QEMU_ARM_BUILD_TESTS)
+    enable_testing()
+    add_test(NAME ocx-qemu-arm
+            COMMAND $<TARGET_FILE:ocx-test-runner>
+                    $<TARGET_FILE:ocx-qemu-arm> Cortex-A53)
+endif()

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ framework for ARMv7 and ARMv8 disassembly.
 * Run [CMake](https://cmake.org) with `gcc` and `g++` in 64bit mode, 
   then `make` to build both the test harness and the unicorn core
 
-        CXX="g++ -m64" CC="gcc -m64" cmake ..
+        CXX="g++ -m64" CC="gcc -m64" cmake -DOCX_QEMU_ARM_BUILD_TESTS=ON ..
         make
 
 * The module should pass the regression tests are specified by the ocx test


### PR DESCRIPTION
The current version of ocx-qemu-arm always builds the unit test. When the project is used as dependency in other projects, it might be handy to disable the unit test to only test the main project.